### PR TITLE
Use .env file for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ echo "ENCRYPTION_KEY=$(openssl rand -hex 32)" >> .env
 echo "JWT_SECRET=$(openssl rand -base64 48)" >> .env
 
 # SESSION_SECRET — used by the frontend to encrypt session cookies
-echo "SESSION_SECRET=$(openssl rand -base64 64)" >> .env
+echo "SESSION_SECRET=$(openssl rand -base64 48)" >> .env
 ```
 
 > **Warning:** Never change `ENCRYPTION_KEY` after initial setup -- existing Mastodon tokens would become undecryptable.

--- a/README.md
+++ b/README.md
@@ -167,17 +167,17 @@ Analytodon runs as three Docker containers -- a **backend** API (NestJS), a **fr
 
 ### 🔑 Generate Secrets
 
-Generate three secrets before starting. The `ENCRYPTION_KEY` encrypts Mastodon OAuth tokens stored in the database -- it **must** be identical in the backend and CLI containers.
+Generate three secrets into the `.env` file before starting.
 
 ```bash
 # ENCRYPTION_KEY — 64-character hex string (32 bytes for AES-256)
-openssl rand -hex 32
+echo "ENCRYPTION_KEY=$(openssl rand -hex 32)" >> .env
 
 # JWT_SECRET — used by the backend to sign authentication tokens
-openssl rand -base64 48
+echo "JWT_SECRET=$(openssl rand -base64 48)" >> .env
 
 # SESSION_SECRET — used by the frontend to encrypt session cookies
-openssl rand -base64 48
+echo "SESSION_SECRET=$(openssl rand -base64 64)" >> .env
 ```
 
 > **Warning:** Never change `ENCRYPTION_KEY` after initial setup -- existing Mastodon tokens would become undecryptable.
@@ -208,8 +208,8 @@ services:
       - mongodb
     environment:
       DB_CLIENT_URL: mongodb://analytodon:<db-password>@mongodb:27017/analytodon?authSource=admin
-      ENCRYPTION_KEY: <your-encryption-key>
-      JWT_SECRET: <your-jwt-secret>
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRES_IN: 1h
       JWT_REFRESH_TOKEN_EXPIRES_IN: 7d
       FRONTEND_URL: https://<your-domain>
@@ -234,7 +234,7 @@ services:
       - backend
     environment:
       API_URL: http://backend:3000
-      SESSION_SECRET: <your-session-secret>
+      SESSION_SECRET: ${SESSION_SECRET}
       MARKETING_URL: https://<your-domain>
       SUPPORT_EMAIL: <your-email>
 
@@ -248,7 +248,7 @@ services:
     environment:
       MONGODB_URI: mongodb://analytodon:<db-password>@mongodb:27017/analytodon?authSource=admin
       MONGODB_DATABASE: analytodon
-      ENCRYPTION_KEY: <your-encryption-key>
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       APP_URL: https://<your-domain>
       LOG_LEVEL: info
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Analytodon runs as three Docker containers -- a **backend** API (NestJS), a **fr
 
 ### 🔑 Generate Secrets
 
-Generate three secrets into the `.env` file before starting.
+Generate three secrets into the `.env` file before starting. The `ENCRYPTION_KEY` encrypts Mastodon OAuth tokens stored in the database -- it **must** be identical in the backend and CLI containers
 
 ```bash
 # ENCRYPTION_KEY — 64-character hex string (32 bytes for AES-256)


### PR DESCRIPTION
This adjusts the documentation to use a `.env` file to store secrets like on the website and also directly generates the random values into the file instead of having to manually copy them. Beyond convenience this also has the added security benefit of those values not being required to leak into the clipboard (or even screen) of the admin's PC. (I initially wanted to PR that to the actual documentation on the website but I couldn't find the source code for the docs :S Ideally this would be adjusted there too)